### PR TITLE
Added prerequisites.debian.sh

### DIFF
--- a/prerequisites.debian.sh
+++ b/prerequisites.debian.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+pip3 install PyQt5
+pip3 install jsonpickle

--- a/prerequisites.debian.sh
+++ b/prerequisites.debian.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+apt-get install git
+apt-get install python3
 pip3 install PyQt5
 pip3 install jsonpickle
+

--- a/prerequisites.debian.sh
+++ b/prerequisites.debian.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 apt-get install git
 apt-get install python3
 pip3 install PyQt5


### PR DESCRIPTION
Hello Markus

There is no installation Script for the (pip) Packages on debian, i added it: prerequisites.debian.sh

there is an error message because ODT Template files are missing (IMG)

Greetings
Marc jr.